### PR TITLE
Ensure windsock path exists

### DIFF
--- a/windsock/src/data.rs
+++ b/windsock/src/data.rs
@@ -1,6 +1,20 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
+
+static INITIALIZED_PATH: OnceLock<()> = OnceLock::new();
 
 pub fn windsock_path() -> PathBuf {
+    let path = windsock_path_inner();
+
+    // Create the directory only the first time this function is called during program execution.
+    if INITIALIZED_PATH.set(()).is_ok() {
+        std::fs::create_dir_all(&path).unwrap();
+    }
+
+    path
+}
+
+fn windsock_path_inner() -> PathBuf {
     // If we are run via cargo (we are in a target directory) use the target directory for storage.
     // Otherwise just fallback to the current working directory.
     let mut path = std::env::current_exe().unwrap();


### PR DESCRIPTION
I hit a panic when running shotover's windsock benches as it assumed that the path returned by windsock_path() existed.
Usually windsock's code will create windsock_path as a required parent of another directory. However to avoid confusing users as I was today, lets make the call to `windsock_path()` ensure at least its own path exists before returning.