### PR TITLE
Release windsock 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "windsock"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windsock"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "database/service benchmarking framework"


### PR DESCRIPTION
https://github.com/shotover/windsock/pull/9 was a breaking change so we need to release 0.2