### PR TITLE
Release windsock 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,7 +1495,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windsock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windsock"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "database/service benchmarking framework"


### PR DESCRIPTION
non-breaking change: upgraded dependencies are not part of public API.
The bincode update will invalidate existing windsock records stored on disk.
But it is expected that this format can change at any time.