### PR TITLE
Update CI test runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,12 +22,12 @@ jobs:
       matrix:
         include:
           - name: Build Release
-            runner: ubuntu-20.04
+            runner: ubuntu-latest
             cargo_flags: --release
             profile: release
 
           - name: Build Debug
-            runner: ubuntu-20.04
+            runner: ubuntu-latest
             cargo_flags:
             profile: debug
 


### PR DESCRIPTION
CI is broken since the test workflows use ubuntu 20.04 which has been removed from github actions.

The underlying OS shouldnt matter for testing windsock, so use the ubuntu-latest image to avoid similar breakage in the future.