### PR TITLE
Fix running example benches on mac os

### DIFF
--- a/windsock/benches/windsock/cassandra.rs
+++ b/windsock/benches/windsock/cassandra.rs
@@ -52,9 +52,8 @@ impl Bench for CassandraBench {
     fn tags(&self) -> HashMap<String, String> {
         [
             ("db".to_owned(), "cassandra".to_owned()),
-            ("topology".to_owned(), "1".to_owned()),
             self.topology.to_tag(),
-            ("message_type".to_owned(), "write1000bytes".to_owned()),
+            ("query".to_owned(), "read_system_peers".to_owned()),
             (
                 "compression".to_owned(),
                 match &self.compression {
@@ -84,9 +83,18 @@ impl Bench for CassandraBench {
         _profiling: Profiling,
         parameters: BenchParameters,
     ) -> Result<()> {
-        let _docker_compose =
-            docker_compose("benches/windsock/config/cassandra-1-docker-compose.yaml");
-        let address = "127.0.0.1:9042";
+        let _docker_compose = match self.topology {
+            Topology::Single => {
+                docker_compose("benches/windsock/config/cassandra-1-docker-compose.yaml")
+            }
+            Topology::Cluster3 => {
+                docker_compose("benches/windsock/config/cassandra-3-docker-compose.yaml")
+            }
+        };
+        let address = match self.topology {
+            Topology::Single => "127.0.0.1:9042",
+            Topology::Cluster3 => "172.16.1.2:9042",
+        };
 
         self.execute_run(address, &parameters).await;
 
@@ -95,13 +103,14 @@ impl Bench for CassandraBench {
 
     async fn run_bencher(
         &self,
-        _resources: &str,
+        resources: &str,
         parameters: BenchParameters,
         reporter: UnboundedSender<Report>,
     ) {
+        let address = resources;
         let session = Arc::new(
             SessionBuilder::new()
-                .known_nodes(["172.16.1.2:9042"])
+                .known_nodes([address])
                 // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
                 // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
                 .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))

--- a/windsock/benches/windsock/config/cassandra-1-docker-compose.yaml
+++ b/windsock/benches/windsock/config/cassandra-1-docker-compose.yaml
@@ -1,25 +1,12 @@
-networks:
-  cluster_subnet:
-    name: cluster_subnet
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.16.1.0/24
-          gateway: 172.16.1.1
-
 services:
   cassandra-one:
-    image: &image shotover/cassandra-test:4.0.6-r1
-    networks:
-      cluster_subnet:
-        ipv4_address: 172.16.1.2
-    environment: &environment
+    image: shotover/cassandra-test:4.0.6-r1
+    ports:
+      - "9042:9042"
+    environment:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
     volumes:
-      # Using volume instead of tmpfs adds 3 seconds to the runtime of the cassandra standard_test_suite but allows running tests that restart nodes
-      &volumes
-      - type: volume
+      - type: tmpfs
         target: /var/lib/cassandra


### PR DESCRIPTION
This repo contains some example benches so that:
* we can test changes to windsock before it reaches shotover
* potential open source users can better understand how to use windsock.

However, looking over the example benches in this repo, the author (me) was pretty careless, and theres some obvious mistakes here.
This PR fixes:
* the Cluster3 benches to actually run against a 3 node cluster
* the Single benches to use docker in a way that is compatible with macos, allowing some of the benches to be run locally.
* the address to actually be passed through as a resource.
  + the resource is a way of passing bench information through orchestrate_local/orchestrate_cloud and run_local, which are executed in different binaries/executables.
  + the user is expected to use json or similar to serialize data across, here we only have one value, the address, we just send it directly.